### PR TITLE
Add 16KB page alignment support for Play Store

### DIFF
--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -56,3 +56,9 @@ target_link_libraries(
   filehash-native
   ${log-lib}
 )
+
+target_link_options(
+  filehash-native
+  PRIVATE
+  "-Wl,-z,max-page-size=16384"
+)


### PR DESCRIPTION
This PR adds support for 16KB page alignment required by Google Play Store. This enhancement ensures compatibility with the Play Store's updated requirements for app distribution and improves performance on supported devices.